### PR TITLE
Header fix

### DIFF
--- a/pairixmodule.c
+++ b/pairixmodule.c
@@ -223,7 +223,6 @@ tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
       if(!val) { Py_DECREF(self->blocknames); return NULL; }
       PyList_SET_ITEM(self->blocknames,i,val);
     }
-    free(*(blocknames));
     free(blocknames);
     return (PyObject *)self;
 }

--- a/pairixmodule.c
+++ b/pairixmodule.c
@@ -30,7 +30,7 @@
  */
 
 #define PY_SSIZE_T_CLEAN
-#include <Python/Python.h>
+#include "Python.h"
 #include "pairix.h"
 
 static PyObject *TabixError;
@@ -217,10 +217,10 @@ tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->tb->idx = ti_index_load(self->fn);
     blocknames = ti_seqname(self->tb->idx, &(self->nblocks));
     self->blocknames = PyList_New(self->nblocks);
-    if(!self->blocknames) { return NULL; } 
+    if(!self->blocknames) { return NULL; }
     for(i=0;i<self->nblocks;i++){
       PyObject *val = Py_BuildValue("s",blocknames[i]);
-      if(!val) { Py_DECREF(self->blocknames); return NULL; } 
+      if(!val) { Py_DECREF(self->blocknames); return NULL; }
       PyList_SET_ITEM(self->blocknames,i,val);
     }
     free(*(blocknames));

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # pysam (https://github.com/pysam-developers)
 # The Github repo for this project is:
 # https://github.com/4dn-dcic/pairix
+# IMPORTANT: use Python 2.7 or above for this package
 
 from setuptools import setup, find_packages, Extension
 
@@ -23,10 +24,10 @@ EXT_MODULES = [
 
 setup(
     name = "pypairix",
-    version = "0.0.3",
+    version = "0.0.4",
     description = "Python interface for pairix",
     url = "https://github.com/4dn-dcic/pairix",
-    download_url = "https://github.com/4dn-dcic/pairix/tarball/0.0.3",
+    download_url = "https://github.com/4dn-dcic/pairix/tarball/0.0.4",
     author = "Soo Lee, Carl Vitzthum",
     author_email = "duplexa@gmail.com",
     license = "MIT",
@@ -37,6 +38,8 @@ setup(
     test_suite = "test",
     classifiers = [
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",

--- a/src/pairixmodule.c
+++ b/src/pairixmodule.c
@@ -30,7 +30,7 @@
  */
 
 #define PY_SSIZE_T_CLEAN
-#include <Python/Python.h>
+#include "Python.h"
 #include "pairix.h"
 
 static PyObject *TabixError;
@@ -223,7 +223,6 @@ tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
       if(!val) { Py_DECREF(self->blocknames); return NULL; } 
       PyList_SET_ITEM(self->blocknames,i,val);
     }
-    free(*(blocknames));
     free(blocknames);
     return (PyObject *)self;
 }

--- a/test/test.py
+++ b/test/test.py
@@ -23,6 +23,10 @@ def read_vcf(filename):
     """Read a VCF file and return a list of [chrom, start, end] items."""
     retval = []
     for line in gzip.open(filename):
+        try:
+            line = line.decode('utf-8')
+        except AttributeError:
+            pass
         fields = line.rstrip().split('\t')
         chrom = fields[0]
         start = fields[1]
@@ -35,6 +39,10 @@ def read_pairs(filename):
     """Read a pairs file and return a list of [chrom1, start1, end1, chrom2, start2, end2] items."""
     retval = []
     for line in gzip.open(filename):
+        try:
+            line = line.decode('utf-8')
+        except AttributeError:
+            pass
         fields = line.rstrip().split('\t')
         chrom1 = fields[1]
         start1 = fields[2]
@@ -92,7 +100,7 @@ class TabixTest_2(unittest.TestCase):
     start = 25944
     end = 27000000
     chrom2 = '20'
-    result = get_result_2D(regions, chrom, start, end, chrom2, 0, sys.maxint)
+    result = get_result_2D(regions, chrom, start, end, chrom2, 0, sys.maxsize)
     tb = pairix.open(TEST_FILE_2D)
 
     def test_querys(self):
@@ -129,7 +137,7 @@ class TabixTest2D(unittest.TestCase):
 class TabixTestBlocknames(unittest.TestCase):
     tb = pairix.open(TEST_FILE_2D)
     def test_blocknames(self):
-      print (str(self.tb.get_blocknames()))  
+      print (str(self.tb.get_blocknames()))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Small but important fixes that will allow pypairix to run on Linux and OSX. NOTE that we now require Python >= 2.7.