### PR TITLE
FF-431

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pairix textfile.gz '<chr1>:<start1>-<end1>[|<chr2>:<start2>-<end2>]'    # make s
 ```
 
 ### Usage examples for pairix
-#### Preparing a double-chromosome-block sorted text file 
+#### Preparing a double-chromosome-block sorted text file
 (column 2 and 6 are chromosomes (chr1 and chr2), column 3 is position of the first coordinate (pos1)).
 ```
 # the following has already be done and the final merged_nodup.tab.chrblock_sorted.txt.gz is already in the samples folder.
@@ -129,36 +129,36 @@ python test/test.py
 ### Usage examples for pypairix
 ```
 # to import and use python module pypairix, add the following in your python script.
-import pairix
+import pypairix
 
 # 2D query usage example 1
-tb=pairix.open("textfile.gz")
+tb=pypairix.open("textfile.gz")
 it = tb.query2D(chrom, start, end, chrom2, start2, end2)
 tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
 print tb_result
 
 # 2D query usage example 2
-tb=pairix.open("textfile.gz")
+tb=pypairix.open("textfile.gz")
 querystr='{}:{}-{}|{}:{}-{}'.format(chrom, start, end, chrom2, start2, end2)
-it = tb.querys2D(querystr) 
+it = tb.querys2D(querystr)
 tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
 print tb_result
 
 # 1D query usage example 1
-tb=pairix.open("textfile.gz")
+tb=pypairix.open("textfile.gz")
 it = tb.query(chrom, start, end)
 tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
 print tb_result
 
 # 1D query usage example 2
-tb=pairix.open("textfile.gz")
+tb=pypairix.open("textfile.gz")
 querystr='{}:{}-{}'.format(chrom, start, end)
-it = tb.querys2D(querystr) 
+it = tb.querys2D(querystr)
 tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
 print tb_result
 
 # get the list of (chr-pair) blocks
-tb=pairix.open("textfile.gz")
+tb=pypairix.open("textfile.gz")
 chrplist = tb.get_blocknames()
 print str(chrplist)
 
@@ -172,5 +172,5 @@ print str(chrplist)
 
 
 ## Utils
-* bgzip (identical to the one from the tabix repo), 
+* bgzip (identical to the one from the tabix repo),
 * merge-pairs. For details about merge-pairs, see https://github.com/hms-dbmi/pairix/tree/master/merge-pairs

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages, Extension
 
 EXT_MODULES = [
-    Extension("pairix",
+    Extension("pypairix",
         sources=[
             "src/bgzf.c", "src/bgzip.c", "src/index.c",
             "src/knetfile.c", "src/kstring.c",
@@ -24,10 +24,16 @@ EXT_MODULES = [
 
 setup(
     name = "pypairix",
-    version = "0.0.4",
-    description = "Python interface for pairix",
+    version = "0.0.5",
+    description = """
+        Pypairix is a Python module for fast querying on a pairix-indexed bgzipped text file that contains a pair of genomic coordinates per line.\n
+        Input file : bgzipped text file, first sorted by two chromosome columns and then by the first position column. The file should accompany an index file (.px2) created with pairix (https://github.com/4dn-dcic/pairix).\n\n
+        Pypairix works with Python >=2.7.\n
+        Dependency: python-devel (python-dev for ubuntu), zlib (zlib1g-dev for ubuntu) if not already installed.\n\n
+        Please reference the README for more information (https://github.com/4dn-dcic/pairix/blob/master/README.md)
+        """,
     url = "https://github.com/4dn-dcic/pairix",
-    download_url = "https://github.com/4dn-dcic/pairix/tarball/0.0.4",
+    download_url = "https://github.com/4dn-dcic/pairix/tarball/0.0.5",
     author = "Soo Lee, Carl Vitzthum",
     author_email = "duplexa@gmail.com",
     license = "MIT",
@@ -37,7 +43,6 @@ setup(
     ext_modules = EXT_MODULES,
     test_suite = "test",
     classifiers = [
-        "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Development Status :: 4 - Beta",

--- a/src/pairixmodule.c
+++ b/src/pairixmodule.c
@@ -26,14 +26,14 @@
  */
 
 /*
- * Contact: Hyeshik Chang <hyeshik@snu.ac.kr>
+ * Contact: Soo Lee (duplexa@gmail.com)
  */
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pairix.h"
 
-static PyObject *TabixError;
+static PyObject *PairixError;
 
 typedef struct {
     PyObject_HEAD
@@ -41,25 +41,25 @@ typedef struct {
     char *fn;
     PyObject *blocknames;
     int nblocks;
-} TabixObject;
+} PairixObject;
 
 typedef struct {
     PyObject_HEAD
-    TabixObject *tbobj;
+    PairixObject *tbobj;
     ti_iter_t iter;
-} TabixIteratorObject;
+} PairixIteratorObject;
 
 
-static PyTypeObject Tabix_Type, TabixIterator_Type;
+static PyTypeObject Pairix_Type, PairixIterator_Type;
 
-/* --- TabixIterator --------------------------------------------------- */
+/* --- PairixIterator --------------------------------------------------- */
 
 static PyObject *
-tabixiter_create(TabixObject *parentidx, ti_iter_t iter)
+pairixiter_create(PairixObject *parentidx, ti_iter_t iter)
 {
-    TabixIteratorObject *self;
+    PairixIteratorObject *self;
 
-    self = PyObject_New(TabixIteratorObject, &TabixIterator_Type);
+    self = PyObject_New(PairixIteratorObject, &PairixIterator_Type);
     if (self == NULL)
         return NULL;
 
@@ -71,7 +71,7 @@ tabixiter_create(TabixObject *parentidx, ti_iter_t iter)
 }
 
 static void
-tabixiter_dealloc(TabixIteratorObject *self)
+pairixiter_dealloc(PairixIteratorObject *self)
 {
     ti_iter_destroy(self->iter);
     Py_DECREF(self->tbobj);
@@ -79,7 +79,7 @@ tabixiter_dealloc(TabixIteratorObject *self)
 }
 
 static PyObject *
-tabixiter_iter(PyObject *self)
+pairixiter_iter(PyObject *self)
 {
     Py_INCREF(self);
     return self;
@@ -92,7 +92,7 @@ tabixiter_iter(PyObject *self)
 #endif
 
 static PyObject *
-tabixiter_iternext(TabixIteratorObject *self)
+pairixiter_iternext(PairixIteratorObject *self)
 {
     const char *chunk;
     int len, i;
@@ -137,17 +137,17 @@ tabixiter_iternext(TabixIteratorObject *self)
         return NULL;
 }
 
-static PyMethodDef tabixiter_methods[] = {
+static PyMethodDef pairixiter_methods[] = {
     {NULL, NULL} /* sentinel */
 };
 
-static PyTypeObject TabixIterator_Type = {
+static PyTypeObject PairixIterator_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "pairix.iter",      /*tp_name*/
-    sizeof(TabixIteratorObject), /*tp_basicsize*/
+    "pypairix.iter",      /*tp_name*/
+    sizeof(PairixIteratorObject), /*tp_basicsize*/
     0,                          /*tp_itemsize*/
     /* methods */
-    (destructor)tabixiter_dealloc,  /*tp_dealloc*/
+    (destructor)pairixiter_dealloc,  /*tp_dealloc*/
     0,                          /*tp_print*/
     0,                          /*tp_getattr*/
     0,                          /*tp_setattr*/
@@ -168,9 +168,9 @@ static PyTypeObject TabixIterator_Type = {
     0,                          /*tp_clear*/
     0,                          /*tp_richcompare*/
     0,                          /*tp_weaklistoffset*/
-    tabixiter_iter,             /*tp_iter*/
-    (iternextfunc)tabixiter_iternext, /*tp_iternext*/
-    tabixiter_methods,          /*tp_methods*/
+    pairixiter_iter,             /*tp_iter*/
+    (iternextfunc)pairixiter_iternext, /*tp_iternext*/
+    pairixiter_methods,          /*tp_methods*/
     0,                          /*tp_members*/
     0,                          /*tp_getset*/
     0,                          /*tp_base*/
@@ -186,12 +186,12 @@ static PyTypeObject TabixIterator_Type = {
 };
 
 
-/* --- Tabix ----------------------------------------------------------- */
+/* --- Pairix ----------------------------------------------------------- */
 
 static PyObject *
-tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+pairix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    TabixObject *self;
+    PairixObject *self;
     const char *fn, *fnidx=NULL;
     static char *kwnames[]={"fn", "fnidx", NULL};
     tabix_t *tb;
@@ -204,11 +204,11 @@ tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     tb = ti_open(fn, fnidx);
     if (tb == NULL) {
-        PyErr_SetString(TabixError, "Can't open the index file.");
+        PyErr_SetString(PairixError, "Can't open the index file.");
         return NULL;
     }
 
-    self = (TabixObject *)type->tp_alloc(type, 0);
+    self = (PairixObject *)type->tp_alloc(type, 0);
     if (self == NULL)
         return NULL;
 
@@ -217,10 +217,10 @@ tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->tb->idx = ti_index_load(self->fn);
     blocknames = ti_seqname(self->tb->idx, &(self->nblocks));
     self->blocknames = PyList_New(self->nblocks);
-    if(!self->blocknames) { return NULL; } 
+    if(!self->blocknames) { return NULL; }
     for(i=0;i<self->nblocks;i++){
       PyObject *val = Py_BuildValue("s",blocknames[i]);
-      if(!val) { Py_DECREF(self->blocknames); return NULL; } 
+      if(!val) { Py_DECREF(self->blocknames); return NULL; }
       PyList_SET_ITEM(self->blocknames,i,val);
     }
     free(blocknames);
@@ -228,7 +228,7 @@ tabix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 static void
-tabix_dealloc(TabixObject *self)
+pairix_dealloc(PairixObject *self)
 {
     free(self->fn);
     Py_DECREF(self->blocknames);
@@ -237,7 +237,7 @@ tabix_dealloc(TabixObject *self)
 }
 
 static PyObject *
-tabix_query(TabixObject *self, PyObject *args)
+pairix_query(PairixObject *self, PyObject *args)
 {
     char *name;
     int begin, end;
@@ -248,15 +248,15 @@ tabix_query(TabixObject *self, PyObject *args)
 
     result = ti_query(self->tb, name, begin, end);
     if (result == NULL) {
-        PyErr_SetString(TabixError, "query failed");
+        PyErr_SetString(PairixError, "query failed");
         return NULL;
     }
 
-    return tabixiter_create(self, result);
+    return pairixiter_create(self, result);
 }
 
 static PyObject *
-tabix_queryi(TabixObject *self, PyObject *args)
+pairix_queryi(PairixObject *self, PyObject *args)
 {
     int tid, begin, end;
     ti_iter_t result;
@@ -266,15 +266,15 @@ tabix_queryi(TabixObject *self, PyObject *args)
 
     result = ti_queryi(self->tb, tid, begin, end);
     if (result == NULL) {
-        PyErr_SetString(TabixError, "query failed");
+        PyErr_SetString(PairixError, "query failed");
         return NULL;
     }
 
-    return tabixiter_create(self, result);
+    return pairixiter_create(self, result);
 }
 
 static PyObject *
-tabix_querys(TabixObject *self, PyObject *args)
+pairix_querys(PairixObject *self, PyObject *args)
 {
     const char *reg;
     ti_iter_t result;
@@ -284,17 +284,17 @@ tabix_querys(TabixObject *self, PyObject *args)
 
     result = ti_querys(self->tb, reg);
     if (result == NULL) {
-        PyErr_SetString(TabixError, "query failed");
+        PyErr_SetString(PairixError, "query failed");
         return NULL;
     }
 
-    return tabixiter_create(self, result);
+    return pairixiter_create(self, result);
 }
 
 /* ------- PAIRIX 2D QUERYING METHODS ------- */
 
 static PyObject *
-tabix_query_2D(TabixObject *self, PyObject *args)
+pairix_query_2D(PairixObject *self, PyObject *args)
 {
     char *name, *name2;
     int begin, end, begin2, end2;
@@ -305,15 +305,15 @@ tabix_query_2D(TabixObject *self, PyObject *args)
 
     result = ti_query_2d(self->tb, name, begin, end, name2, begin2, end2);
     if (result == NULL) {
-        PyErr_SetString(TabixError, "query failed");
+        PyErr_SetString(PairixError, "query failed");
         return NULL;
     }
 
-    return tabixiter_create(self, result);
+    return pairixiter_create(self, result);
 }
 
 static PyObject *
-tabix_queryi_2D(TabixObject *self, PyObject *args)
+pairix_queryi_2D(PairixObject *self, PyObject *args)
 {
     int tid, begin, end, begin2, end2;
     ti_iter_t result;
@@ -323,15 +323,15 @@ tabix_queryi_2D(TabixObject *self, PyObject *args)
 
     result = ti_queryi_2d(self->tb, tid, begin, end, begin2, end2);
     if (result == NULL) {
-        PyErr_SetString(TabixError, "query failed");
+        PyErr_SetString(PairixError, "query failed");
         return NULL;
     }
 
-    return tabixiter_create(self, result);
+    return pairixiter_create(self, result);
 }
 
 static PyObject *
-tabix_querys_2D(TabixObject *self, PyObject *args)
+pairix_querys_2D(PairixObject *self, PyObject *args)
 {
     const char *reg;
     ti_iter_t result;
@@ -341,39 +341,39 @@ tabix_querys_2D(TabixObject *self, PyObject *args)
 
     result = ti_querys_2d(self->tb, reg);
     if (result == NULL) {
-        PyErr_SetString(TabixError, "query failed");
+        PyErr_SetString(PairixError, "query failed");
         return NULL;
     }
 
-    return tabixiter_create(self, result);
+    return pairixiter_create(self, result);
 }
 
 
 static PyObject *
-tabix_get_blocknames(TabixObject *self)
+pairix_get_blocknames(PairixObject *self)
 {
   return self->blocknames;
 }
 
 
 static PyObject *
-tabix_repr(TabixObject *self)
+pairix_repr(PairixObject *self)
 {
 #if PY_MAJOR_VERSION < 3
-    return PyString_FromFormat("<tabix fn=\"%s\">", self->fn);
+    return PyString_FromFormat("<pypairix fn=\"%s\">", self->fn);
 #else
-    return PyUnicode_FromFormat("<tabix fn=\"%s\">", self->fn);
+    return PyUnicode_FromFormat("<pypairix fn=\"%s\">", self->fn);
 #endif
 }
 
-static PyMethodDef tabix_methods[] = {
+static PyMethodDef pairix_methods[] = {
     {
         "query",
-        (PyCFunction)tabix_query,
+        (PyCFunction)pairix_query,
         METH_VARARGS,
         PyDoc_STR("Retrieve items within a region.\n\n"
                   "    >>> tb.query(\"chr1\", 1000, 2000)\n"
-                  "    <tabix.iter at 0x17b86e50>\n\n"
+                  "    <pypairix.iter at 0x17b86e50>\n\n"
                   "Parameters\n"
                   "----------\n"
                   "name : str\n"
@@ -385,11 +385,11 @@ static PyMethodDef tabix_methods[] = {
     },
     {
         "queryi",
-        (PyCFunction)tabix_queryi,
+        (PyCFunction)pairix_queryi,
         METH_VARARGS,
         PyDoc_STR("Retrieve items within a region.\n\n"
                   "    >>> tb.queryi(0, 1000, 2000)\n"
-                  "    <tabix.iter at 0x17b86e50>\n\n"
+                  "    <pypairix.iter at 0x17b86e50>\n\n"
                   "Parameters\n"
                   "----------\n"
                   "tid : int\n"
@@ -401,11 +401,11 @@ static PyMethodDef tabix_methods[] = {
     },
     {
         "querys",
-        (PyCFunction)tabix_querys,
+        (PyCFunction)pairix_querys,
         METH_VARARGS,
         PyDoc_STR("Retrieve items within a region.\n\n"
                   "    >>> tb.querys(\"chr1:1000-2000\")\n"
-                  "    <tabix.iter at 0x17b86e50>\n\n"
+                  "    <pypairix.iter at 0x17b86e50>\n\n"
                   "Parameters\n"
                   "----------\n"
                   "region : str\n"
@@ -413,11 +413,11 @@ static PyMethodDef tabix_methods[] = {
     },
     {
         "query2D",
-        (PyCFunction)tabix_query_2D,
+        (PyCFunction)pairix_query_2D,
         METH_VARARGS,
         PyDoc_STR("Retrieve items within a region.\n\n"
                   "    >>> tb.query(\"chr1\", 1000, 2000)\n"
-                  "    <tabix.iter at 0x17b86e50>\n\n"
+                  "    <pypairix.iter at 0x17b86e50>\n\n"
                   "Parameters\n"
                   "----------\n"
                   "name : str\n"
@@ -429,11 +429,11 @@ static PyMethodDef tabix_methods[] = {
     },
     {
         "queryi2D",
-        (PyCFunction)tabix_queryi_2D,
+        (PyCFunction)pairix_queryi_2D,
         METH_VARARGS,
         PyDoc_STR("Retrieve items within a region.\n\n"
                   "    >>> tb.queryi(0, 1000, 2000)\n"
-                  "    <tabix.iter at 0x17b86e50>\n\n"
+                  "    <pypairix.iter at 0x17b86e50>\n\n"
                   "Parameters\n"
                   "----------\n"
                   "tid : int\n"
@@ -445,11 +445,11 @@ static PyMethodDef tabix_methods[] = {
     },
     {
         "querys2D",
-        (PyCFunction)tabix_querys_2D,
+        (PyCFunction)pairix_querys_2D,
         METH_VARARGS,
         PyDoc_STR("Retrieve items within a region.\n\n"
                   "    >>> tb.querys(\"chr1:1000-2000\")\n"
-                  "    <tabix.iter at 0x17b86e50>\n\n"
+                  "    <pypairix.iter at 0x17b86e50>\n\n"
                   "Parameters\n"
                   "----------\n"
                   "region : str\n"
@@ -457,7 +457,7 @@ static PyMethodDef tabix_methods[] = {
     },
     {
        "get_blocknames",
-       (PyCFunction)tabix_get_blocknames,
+       (PyCFunction)pairix_get_blocknames,
         METH_VARARGS,
         PyDoc_STR("Retrieve list of keys (either chromosomes(1D-indexed) or chromosome pairs(2D-indexed)).\n\n")
     },
@@ -472,26 +472,22 @@ static PyMethodDef tabix_methods[] = {
     */
     {NULL, NULL}           /* sentinel */
 };
-/*
-	ti_iter_t ti_query(tabix_t *t, const char *name, int beg, int end);
-	ti_iter_t ti_queryi(tabix_t *t, int tid, int beg, int end);
-	ti_iter_t ti_querys(tabix_t *t, const char *reg);
-*/
 
-static PyTypeObject Tabix_Type = {
+
+static PyTypeObject Pairix_Type = {
     /* The ob_type field must be initialized in the module init function
      * to be portable to Windows without using C++. */
     PyVarObject_HEAD_INIT(NULL, 0)
-    "pairix.open",              /*tp_name*/
-    sizeof(TabixObject),        /*tp_basicsize*/
+    "pypairix.open",              /*tp_name*/
+    sizeof(PairixObject),        /*tp_basicsize*/
     0,                          /*tp_itemsize*/
     /* methods */
-    (destructor)tabix_dealloc,  /*tp_dealloc*/
+    (destructor)pairix_dealloc,  /*tp_dealloc*/
     0,                          /*tp_print*/
     0,                          /*tp_getattr*/
     0,                          /*tp_setattr*/
     0,                          /*tp_compare*/
-    (reprfunc)tabix_repr,       /*tp_repr*/
+    (reprfunc)pairix_repr,       /*tp_repr*/
     0,                          /*tp_as_number*/
     0,                          /*tp_as_sequence*/
     0,                          /*tp_as_mapping*/
@@ -509,7 +505,7 @@ static PyTypeObject Tabix_Type = {
     0,                          /*tp_weaklistoffset*/
     0,                          /*tp_iter*/
     0,                          /*tp_iternext*/
-    tabix_methods,              /*tp_methods*/
+    pairix_methods,              /*tp_methods*/
     0,                          /*tp_members*/
     0,                          /*tp_getset*/
     0,                          /*tp_base*/
@@ -519,27 +515,26 @@ static PyTypeObject Tabix_Type = {
     0,                          /*tp_dictoffset*/
     0,                          /*tp_init*/
     0,                          /*tp_alloc*/
-    (newfunc)tabix_new,         /*tp_new*/
+    (newfunc)pairix_new,         /*tp_new*/
     0,                          /*tp_free*/
     0,                          /*tp_is_gc*/
 };
 /* --------------------------------------------------------------------- */
 
-static PyMethodDef tabix_functions[] = {
+static PyMethodDef pairix_functions[] = {
     {NULL, NULL} /* sentinel */
 };
 
 PyDoc_STRVAR(module_doc,
-"Python interface to tabix, Heng Li's generic indexer for TAB-delimited "
-"genome position filesThis is a template module just for instruction.");
+"Python interface to pairix.");
 
 #if PY_MAJOR_VERSION >= 3
-static struct PyModuleDef tabixmodule = {
+static struct PyModuleDef pypairixmodule = {
     PyModuleDef_HEAD_INIT,
-    "pairix",
+    "pypairix",
     module_doc,
     -1,
-    tabix_functions,
+    pairix_functions,
     NULL,
     NULL,
     NULL,
@@ -548,36 +543,36 @@ static struct PyModuleDef tabixmodule = {
 #endif
 
 #if PY_MAJOR_VERSION < 3
-PyMODINIT_FUNC initpairix(void)
+PyMODINIT_FUNC initpypairix(void)
 #else
-PyMODINIT_FUNC PyInit_pairix(void)
+PyMODINIT_FUNC PyInit_pypairix(void)
 #endif
 {
     PyObject *m;
 
-    if (PyType_Ready(&Tabix_Type) < 0)
+    if (PyType_Ready(&Pairix_Type) < 0)
         goto fail;
-    if (PyType_Ready(&TabixIterator_Type) < 0)
+    if (PyType_Ready(&PairixIterator_Type) < 0)
         goto fail;
 
 #if PY_MAJOR_VERSION < 3
-    m = Py_InitModule3("pairix", tabix_functions, module_doc);
+    m = Py_InitModule3("pypairix", pairix_functions, module_doc);
 #else
-    m = PyModule_Create(&tabixmodule);
+    m = PyModule_Create(&pypairixmodule);
 #endif
     if (m == NULL)
         goto fail;
 
-    if (TabixError == NULL) {
-        TabixError = PyErr_NewException("pairix.TabixError", NULL, NULL);
-        if (TabixError == NULL)
+    if (PairixError == NULL) {
+        PairixError = PyErr_NewException("pypairix.PairixError", NULL, NULL);
+        if (PairixError == NULL)
             goto fail;
     }
-    Py_INCREF(TabixError);
-    PyModule_AddObject(m, "TabixError", TabixError);
+    Py_INCREF(PairixError);
+    PyModule_AddObject(m, "PairixError", PairixError);
 
-    PyModule_AddObject(m, "open", (PyObject *)&Tabix_Type);
-    PyModule_AddObject(m, "iter", (PyObject *)&TabixIterator_Type);
+    PyModule_AddObject(m, "open", (PyObject *)&Pairix_Type);
+    PyModule_AddObject(m, "iter", (PyObject *)&PairixIterator_Type);
 
 #if PY_MAJOR_VERSION >= 3
     return m;

--- a/test/test.py
+++ b/test/test.py
@@ -7,13 +7,16 @@ First, ensure you have fully installed the pypairix package:
 `pip install pypairix --user`
 OR
 `sudo python setup.py install`
+
+If you're having trouble running this file, try installing
+python-dev and zlib1g-dev.
 """
 
 
 import unittest
 import gzip
 import sys
-import pairix
+import pypairix
 
 TEST_FILE_2D = 'samples/merged_nodup.tab.chrblock_sorted.txt.gz'
 TEST_FILE_1D = 'samples/SRR1171591.variants.snp.vqsr.p.vcf.gz'
@@ -78,18 +81,18 @@ class TabixTest(unittest.TestCase):
     start = 25944
     end = 27000000
     result = get_result(regions, chrom, start, end)
-    tb = pairix.open(TEST_FILE_1D)
+    pr = pypairix.open(TEST_FILE_1D)
 
     def test_query(self):
-        it = self.tb.query(self.chrom, self.start, self.end)
-        tb_result = [[x[0], x[1], x[1]] for x in it]
-        self.assertEqual(self.result, tb_result)
+        it = self.pr.query(self.chrom, self.start, self.end)
+        pr_result = [[x[0], x[1], x[1]] for x in it]
+        self.assertEqual(self.result, pr_result)
 
     def test_querys(self):
         query = '{}:{}-{}'.format(self.chrom, self.start, self.end)
-        it = self.tb.querys(query)
-        tb_result = [[x[0], x[1], x[1]] for x in it]
-        self.assertEqual(self.result, tb_result)
+        it = self.pr.querys(query)
+        pr_result = [[x[0], x[1], x[1]] for x in it]
+        self.assertEqual(self.result, pr_result)
 
 
 
@@ -101,13 +104,13 @@ class TabixTest_2(unittest.TestCase):
     end = 27000000
     chrom2 = '20'
     result = get_result_2D(regions, chrom, start, end, chrom2, 0, sys.maxsize)
-    tb = pairix.open(TEST_FILE_2D)
+    pr = pypairix.open(TEST_FILE_2D)
 
     def test_querys(self):
         query = '{}:{}-{}|{}'.format(self.chrom, self.start, self.end, self.chrom2)
-        it = self.tb.querys2D(query)
-        tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
-        self.assertEqual(self.result, tb_result)
+        it = self.pr.querys2D(query)
+        pr_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
+        self.assertEqual(self.result, pr_result)
 
 
 ## 2D query on 2D indexed file
@@ -120,24 +123,25 @@ class TabixTest2D(unittest.TestCase):
     start2 = 50000000
     end2 = 60000000
     result = get_result_2D(regions, chrom, start, end, chrom2, start2, end2)
-    tb = pairix.open(TEST_FILE_2D)
+    pr = pypairix.open(TEST_FILE_2D)
 
     def test_query2(self):
-        it = self.tb.query2D(self.chrom, self.start, self.end, self.chrom2, self.start2, self.end2)
-        tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
-        self.assertEqual(self.result, tb_result)
+        it = self.pr.query2D(self.chrom, self.start, self.end, self.chrom2, self.start2, self.end2)
+        pr_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
+        self.assertEqual(self.result, pr_result)
 
     def test_querys_2(self):
         query = '{}:{}-{}|{}:{}-{}'.format(self.chrom, self.start, self.end, self.chrom2, self.start2, self.end2)
-        it = self.tb.querys2D(query)
-        tb_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
-        self.assertEqual(self.result, tb_result)
+        it = self.pr.querys2D(query)
+        pr_result = [[x[1], x[2], x[2], x[5], x[6], x[6]] for x in it]
+        self.assertEqual(self.result, pr_result)
 
 
 class TabixTestBlocknames(unittest.TestCase):
-    tb = pairix.open(TEST_FILE_2D)
+    pr = pypairix.open(TEST_FILE_2D)
+
     def test_blocknames(self):
-      print (str(self.tb.get_blocknames()))
+      print (str(self.pr.get_blocknames()))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
renamed pairix module to pypairix; cleaned up a lot of function names in pairixmodule.c. Adjusted setup.py and changed test comments for release 0.0.5. Soo changed readme, I made several small changes too.

TESTED ON OSX AND ORCHESTRA FOR PYTHON 2.7 and 3