### PR TITLE
free BGZF

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -254,6 +254,11 @@ int main(int argc, char *argv[])
         }
         ti_index_destroy(idx);
         free(names);
+        free(fp->uncompressed_block);
+        free(fp->compressed_block);
+        free(fp->cache);
+        free(fp->fp);
+        free(fp);
         return 0;
     }
     if(check_triangle_only){


### PR DESCRIPTION
Hi,
I noticed that in the HEAP/LEAK SUMMARY, there was:
```
test bgzf block count
==5115== Memcheck, a memory error detector
==5115== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==5115== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==5115== Command: pairix -B samples/test_4dn.pairs.gz
==5115== HEAP SUMMARY:
==5115==     in use at exit: 131,296 bytes in 5 blocks
==5115==   total heap usage: 60,209 allocs, 60,204 frees, 75,224,158 bytes allocated
==5115== 
==5115== 131,296 (56 direct, 131,240 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
==5115==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5115==    by 0x40321F: bgzf_read_init (bgzf.c:105)
==5115==    by 0x4036FF: bgzf_open (bgzf.c:143)
==5115==    by 0x4023B3: main (main.c:251)
==5115== 
==5115== LEAK SUMMARY:
==5115==    definitely lost: 56 bytes in 1 blocks
==5115==    indirectly lost: 131,240 bytes in 4 blocks
==5115==      possibly lost: 0 bytes in 0 blocks
==5115==    still reachable: 0 bytes in 0 blocks
==5115==         suppressed: 0 bytes in 0 blocks
==5115== 
==5115== For counts of detected and suppressed errors, rerun with: -v
==5115== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
To fix this leakage, I added some free but I don't know if it is relevant...